### PR TITLE
Add intellisense support for Swoole

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
     "require": {
         "utopia-php/swoole": "dev-master",
         "utopia-php/cli": "dev-master"
+    },
+    "require-dev": {
+        "swoole/ide-helper": "4.6.7"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdaac2c6cd05b89b310b51d44942be54",
+    "content-hash": "7eeef43e4e9ee9eb6d9aeeed25d7095b",
     "packages": [
         {
             "name": "utopia-php/cli",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/cli.git",
-                "reference": "69ae40187fb4b68ef14f0224a68d9cc016b83634"
+                "reference": "2186679c9a5b368a55fcde61ad3b7551c9897578"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/cli/zipball/69ae40187fb4b68ef14f0224a68d9cc016b83634",
-                "reference": "69ae40187fb4b68ef14f0224a68d9cc016b83634",
+                "url": "https://api.github.com/repos/utopia-php/cli/zipball/2186679c9a5b368a55fcde61ad3b7551c9897578",
+                "reference": "2186679c9a5b368a55fcde61ad3b7551c9897578",
                 "shasum": ""
             },
             "require": {
@@ -56,22 +56,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/cli/issues",
-                "source": "https://github.com/utopia-php/cli/tree/0.10.0"
+                "source": "https://github.com/utopia-php/cli/tree/master"
             },
-            "time": "2021-01-26T16:35:15+00:00"
+            "time": "2021-10-26T03:50:44+00:00"
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.10.1",
+            "version": "0.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/framework.git",
-                "reference": "9af223a1df4734ca92e39d414eacb9c61d1d92ae"
+                "reference": "c86fc078ef258f3c88d3a25233202267314df3a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/framework/zipball/9af223a1df4734ca92e39d414eacb9c61d1d92ae",
-                "reference": "9af223a1df4734ca92e39d414eacb9c61d1d92ae",
+                "url": "https://api.github.com/repos/utopia-php/framework/zipball/c86fc078ef258f3c88d3a25233202267314df3a9",
+                "reference": "c86fc078ef258f3c88d3a25233202267314df3a9",
                 "shasum": ""
             },
             "require": {
@@ -105,9 +105,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/framework/issues",
-                "source": "https://github.com/utopia-php/framework/tree/0.10.1"
+                "source": "https://github.com/utopia-php/framework/tree/0.19.0"
             },
-            "time": "2021-02-10T12:42:28+00:00"
+            "time": "2021-10-08T11:46:20+00:00"
         },
         {
             "name": "utopia-php/swoole",
@@ -115,12 +115,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/swoole.git",
-                "reference": "63168a82037f371516a199d75da101c8caa3edc1"
+                "reference": "c9664cf6f9e4a671d72c8d47e33e5df3e8869914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/swoole/zipball/63168a82037f371516a199d75da101c8caa3edc1",
-                "reference": "63168a82037f371516a199d75da101c8caa3edc1",
+                "url": "https://api.github.com/repos/utopia-php/swoole/zipball/c9664cf6f9e4a671d72c8d47e33e5df3e8869914",
+                "reference": "c9664cf6f9e4a671d72c8d47e33e5df3e8869914",
                 "shasum": ""
             },
             "require": {
@@ -162,12 +162,65 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/swoole/issues",
-                "source": "https://github.com/utopia-php/swoole/tree/0.2.1"
+                "source": "https://github.com/utopia-php/swoole/tree/master"
             },
-            "time": "2021-02-10T06:20:43+00:00"
+            "time": "2021-10-25T10:17:24+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "swoole/ide-helper",
+            "version": "4.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swoole/ide-helper.git",
+                "reference": "0d1409b8274117addfe64d3ea412812a69807411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swoole/ide-helper/zipball/0d1409b8274117addfe64d3ea412812a69807411",
+                "reference": "0d1409b8274117addfe64d3ea412812a69807411",
+                "shasum": ""
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "~6.5.0",
+                "laminas/laminas-code": "~3.4.0",
+                "squizlabs/php_codesniffer": "~3.5.0",
+                "symfony/filesystem": "~4.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Team Swoole",
+                    "email": "team@swoole.com"
+                }
+            ],
+            "description": "IDE help files for Swoole.",
+            "support": {
+                "issues": "https://github.com/swoole/ide-helper/issues",
+                "source": "https://github.com/swoole/ide-helper/tree/4.6.7"
+            },
+            "funding": [
+                {
+                    "url": "https://gitee.com/swoole/swoole?donate=true",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/swoole",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/swoole-src",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2021-05-14T16:05:16+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
@@ -178,5 +231,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
By default, IDEs with LSP will complain about Swoole code, so this PR adds a dev dependency that brings syntax support for Swoole methods.